### PR TITLE
Upload built plugin for builds

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,7 +13,10 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -30,3 +33,10 @@ jobs:
 
       - name: Run plugin verifier
         run: ./gradlew runPluginVerifier
+
+      - uses: actions/upload-artifact@v3
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          name: plugin
+          path: build/distributions/*.zip
+          retention-days: 10


### PR DESCRIPTION
This way, we can download and test this before publishing.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>

See https://github.com/pyvenvmanage/PyVenvManage/actions/runs/3551789326#artifacts, which can now be downloaded and installed manually. 
